### PR TITLE
ATH-607: feature/multiple-metrics: Added support for evaluators to return multiple metrics

### DIFF
--- a/athina/evals/llm/context_contains_enough_information/evaluator.py
+++ b/athina/evals/llm/context_contains_enough_information/evaluator.py
@@ -2,6 +2,7 @@ from typing import List
 from ..llm_evaluator import LlmEvaluator
 from .examples import CONTEXT_CONTAINS_ENOUGH_INFORMATION_EXAMPLES
 from ..eval_type import AthinaEvalTypeId
+from athina.metrics.metric_type import MetricType
 
 
 class ContextContainsEnoughInformation(LlmEvaluator):
@@ -40,8 +41,8 @@ class ContextContainsEnoughInformation(LlmEvaluator):
         return "Context Contains Enough Information"
 
     @property
-    def metric_id(self) -> str:
-        return None
+    def metric_ids(self) -> str:
+        return [MetricType.PASSED.value]
 
     @property
     def default_model(self):

--- a/athina/evals/llm/custom/evaluator.py
+++ b/athina/evals/llm/custom/evaluator.py
@@ -10,7 +10,7 @@ class CustomLlmEval(LlmEvaluator):
     """
 
     _display_name: str = None
-    _metric_id: str = None
+    _metric_ids: List[str] = None
     _model: str = None
     _required_args: List[str] = None
     _examples: List[FewShotExample] = None
@@ -20,7 +20,7 @@ class CustomLlmEval(LlmEvaluator):
     def __init__(
         self,
         display_name: str = None,
-        metric_id: str = None,
+        metric_ids: List[str] = None,
         model: str = None,
         required_args: List[str] = [],
         examples: List[FewShotExample] = [],
@@ -34,7 +34,7 @@ class CustomLlmEval(LlmEvaluator):
             raise ValueError("model is not defined")
 
         self._display_name = display_name
-        self._metric_id = metric_id
+        self._metric_ids = metric_ids
         self._model = model
         self._required_args = required_args
         self._examples = examples
@@ -57,8 +57,8 @@ class CustomLlmEval(LlmEvaluator):
         return AthinaEvalTypeId.CUSTOM.value
         
     @property
-    def metric_id(self) -> str:
-        return self._metric_id
+    def metric_ids(self) -> str:
+        return self._metric_ids
         
     @property
     def display_name(self):

--- a/athina/evals/llm/custom_grader/evaluator.py
+++ b/athina/evals/llm/custom_grader/evaluator.py
@@ -22,8 +22,8 @@ class CustomGrader(LlmEvaluator):
         return AthinaEvalTypeId.CUSTOM.value
 
     @property
-    def metric_id(self) -> str:
-        return None
+    def metric_ids(self) -> str:
+        return []
 
     @property
     def display_name(self):

--- a/athina/evals/llm/does_response_answer_query/evaluator.py
+++ b/athina/evals/llm/does_response_answer_query/evaluator.py
@@ -52,8 +52,8 @@ class DoesResponseAnswerQuery(LlmEvaluator):
         return DOES_RESPONSE_ANSWER_QUERY_EVAL_EXAMPLES
 
     @property
-    def metric_id(self) -> str:
-        return None
+    def metric_ids(self) -> str:
+        return []
 
     def _user_message(
         self,

--- a/athina/evals/llm/does_response_answer_query/evaluator.py
+++ b/athina/evals/llm/does_response_answer_query/evaluator.py
@@ -2,7 +2,7 @@ from typing import List
 from ..llm_evaluator import LlmEvaluator
 from .examples import DOES_RESPONSE_ANSWER_QUERY_EVAL_EXAMPLES
 from ..eval_type import AthinaEvalTypeId
-
+from athina.metrics.metric_type import MetricType
 
 class DoesResponseAnswerQuery(LlmEvaluator):
     """
@@ -53,7 +53,7 @@ class DoesResponseAnswerQuery(LlmEvaluator):
 
     @property
     def metric_ids(self) -> str:
-        return []
+        return [MetricType.PASSED.value]
 
     def _user_message(
         self,

--- a/athina/evals/llm/faithfulness/evaluator.py
+++ b/athina/evals/llm/faithfulness/evaluator.py
@@ -2,7 +2,7 @@ from typing import List
 from ..llm_evaluator import LlmEvaluator
 from .examples import FAITHFULNESS_EVAL_EXAMPLES
 from ..eval_type import AthinaEvalTypeId
-
+from athina.metrics.metric_type import MetricType
 
 class Faithfulness(LlmEvaluator):
     """
@@ -41,7 +41,7 @@ class Faithfulness(LlmEvaluator):
 
     @property
     def metric_ids(self) -> str:
-        return []
+        return [MetricType.PASSED.value]
 
     @property
     def default_model(self):

--- a/athina/evals/llm/faithfulness/evaluator.py
+++ b/athina/evals/llm/faithfulness/evaluator.py
@@ -40,8 +40,8 @@ class Faithfulness(LlmEvaluator):
         return "Faithfulness"
 
     @property
-    def metric_id(self) -> str:
-        return None
+    def metric_ids(self) -> str:
+        return []
 
     @property
     def default_model(self):

--- a/athina/evals/llm/llm_evaluator.py
+++ b/athina/evals/llm/llm_evaluator.py
@@ -197,8 +197,6 @@ class LlmEvaluator(ABC):
             model=self._model,
             metrics=metrics,
         )
-        print("LLM EVAL RESULT")
-        print(llm_eval_result)
         return {k: v for k, v in llm_eval_result.items() if v is not None}
 
     def configure_experiment(self, experiment: AthinaExperiment):
@@ -295,7 +293,6 @@ class LlmEvaluator(ABC):
         """
 
         # Create eval request
-        print("logging eval request")
         eval_request_id = AthinaLoggingHelper.create_eval_request(
             eval_name=self.name, request_data={"data": data}, request_type="batch"
         )
@@ -320,7 +317,6 @@ class LlmEvaluator(ABC):
             eval_results = list(self._run_batch_generator(data))
 
         # Log evaluation results to Athina
-        print("logging eval result")
         AthinaLoggingHelper.log_eval_results(
             eval_request_id=eval_request_id,
             eval_results=eval_results,

--- a/athina/evals/llm/llm_evaluator.py
+++ b/athina/evals/llm/llm_evaluator.py
@@ -193,7 +193,7 @@ class LlmEvaluator(ABC):
             reason=explanation,
             runtime=eval_runtime_ms,
             model=self._model,
-            metric=metric,
+            metrics=[metric],
         )
         return {k: v for k, v in llm_eval_result.items() if v is not None}
 

--- a/athina/evals/llm/llm_evaluator.py
+++ b/athina/evals/llm/llm_evaluator.py
@@ -1,3 +1,4 @@
+import traceback
 from abc import ABC, abstractmethod
 import time
 from typing import List, Optional
@@ -10,6 +11,7 @@ from athina.helpers.logger import logger
 from athina.helpers.athina_logging_helper import AthinaLoggingHelper
 from athina.interfaces.data import DataPoint
 from athina.services.athina_api_service import AthinaApiService
+from athina.metrics.metric_type import MetricType
 from .example import FewShotExample
 
 
@@ -95,8 +97,8 @@ class LlmEvaluator(ABC):
 
     @property
     @abstractmethod
-    def metric_id(self) -> str:
-        """The metric computed by the evaluator."""
+    def metric_ids(self) -> str:
+        """The metrics computed by the evaluator."""
         pass
 
     @property
@@ -168,16 +170,16 @@ class LlmEvaluator(ABC):
             temperature=self.TEMPERATURE,
         )
 
+        metrics = []
         try:
-            metric = None
             result = chat_completion_response_json["result"]
             explanation = chat_completion_response_json["explanation"]
             failure = bool(result == "Fail")
+            passed_value = 1 - float(failure)
+            metrics.append(LlmEvalResultMetric(id=MetricType.PASSED.value, value=passed_value))
             if "score" in chat_completion_response_json:
                 score = chat_completion_response_json["score"]
-                metric = LlmEvalResultMetric(id=self.metric_id, value=score)
-            else:
-                metric = LlmEvalResultMetric(id="failed", value=float(failure))
+                metrics.append(LlmEvalResultMetric(id=self.metric_id, value=score))
 
         except Exception as e:
             logger.error(f"Error occurred during eval: {e}")
@@ -193,8 +195,10 @@ class LlmEvaluator(ABC):
             reason=explanation,
             runtime=eval_runtime_ms,
             model=self._model,
-            metrics=[metric],
+            metrics=metrics,
         )
+        print("LLM EVAL RESULT")
+        print(llm_eval_result)
         return {k: v for k, v in llm_eval_result.items() if v is not None}
 
     def configure_experiment(self, experiment: AthinaExperiment):
@@ -280,6 +284,7 @@ class LlmEvaluator(ABC):
                 yield self._evaluate(**entry)
             except Exception as e:
                 logger.error(f"Error evaluating entry {entry}: {e}")
+                traceback.print_exc()
                 yield None
 
     def run_batch(
@@ -290,6 +295,7 @@ class LlmEvaluator(ABC):
         """
 
         # Create eval request
+        print("logging eval request")
         eval_request_id = AthinaLoggingHelper.create_eval_request(
             eval_name=self.name, request_data={"data": data}, request_type="batch"
         )
@@ -314,6 +320,7 @@ class LlmEvaluator(ABC):
             eval_results = list(self._run_batch_generator(data))
 
         # Log evaluation results to Athina
+        print("logging eval result")
         AthinaLoggingHelper.log_eval_results(
             eval_request_id=eval_request_id,
             eval_results=eval_results,

--- a/athina/evals/llm/summary_accuracy/evaluator.py
+++ b/athina/evals/llm/summary_accuracy/evaluator.py
@@ -117,10 +117,10 @@ class SummaryAccuracy(LlmEvaluator):
             reason=self.reason(),
             runtime=eval_runtime_ms,
             model=self._model,
-            metric={
+            metrics=[{
                 "id": self.metric_id,
                 "value": summary_eval_result[self.metric_id],
-            },
+            }],
         )
 
         return {k: v for k, v in llm_eval_result.items() if v is not None}

--- a/athina/evals/llm/summary_accuracy/evaluator.py
+++ b/athina/evals/llm/summary_accuracy/evaluator.py
@@ -27,11 +27,6 @@ class SummaryAccuracy(LlmEvaluator):
         n_questions: int = 10,
         model: str = "gpt-4-1106-preview",
         question_answerer: Optional[QuestionAnswerer] = None,
-        metrics: List[MetricType] = [
-            MetricType.AGREEMENT_SCORE,
-            MetricType.CONTRADICTION_SCORE,
-            MetricType.HALLUCINATION_SCORE
-        ],
     ):
         """
         Initialize the evaluator with given parameters.
@@ -56,18 +51,21 @@ class SummaryAccuracy(LlmEvaluator):
         else:
             self.question_answerer = question_answerer
         self.n_instances = 0
-        self.metrics: List[MetricType] = metrics
         self.label_counts = {}
-        for metric in metrics:
+        for metric in self.metric_ids:
             setattr(self, f"{metric}_scores", {})
 
     @property
     def name(self):
-        return AthinaEvalTypeId.CUSTOM.value
+        return AthinaEvalTypeId.SUMMARY_ACCURACY.value
         
     @property
-    def metric_id(self) -> str:
-        return MetricType.AGREEMENT_SCORE.value
+    def metric_ids(self) -> str:
+        return [
+            MetricType.AGREEMENT_SCORE,
+            MetricType.CONTRADICTION_SCORE,
+            MetricType.HALLUCINATION_SCORE
+        ]
         
     @property
     def display_name(self):
@@ -89,7 +87,13 @@ class SummaryAccuracy(LlmEvaluator):
         return False
     
     def reason(self) -> str:
-        return ""
+        disagreement_answers = self._disagreement_answers()
+        if len(disagreement_answers) == 0:
+            return "No disagreement between document and summary."
+        reason_str = ""
+        for question, answer_doc, answer_sum in disagreement_answers:
+            reason_str += f"{question}\n- Document: {answer_doc}\n- Summary: {answer_sum}\n"
+        return reason_str
 
 
     def _evaluate(self, **instance) -> LlmEvalResult:
@@ -109,6 +113,8 @@ class SummaryAccuracy(LlmEvaluator):
         end_time = time.time()
         eval_runtime_ms = int((end_time - start_time) * 1000)
         
+        metrics = [{ "id": metric_id.value, "value": summary_eval_result[metric_id.value] } for metric_id in self.metric_ids]
+
         llm_eval_result = LlmEvalResult(
             name=self.name,
             display_name=self.display_name,
@@ -117,41 +123,59 @@ class SummaryAccuracy(LlmEvaluator):
             reason=self.reason(),
             runtime=eval_runtime_ms,
             model=self._model,
-            metrics=[{
-                "id": self.metric_id,
-                "value": summary_eval_result[self.metric_id],
-            }],
+            metrics=metrics,
         )
 
         return {k: v for k, v in llm_eval_result.items() if v is not None}
     
+    def _disagreement_answers(self):
+        """Return the questions for which the Y/N answers do not match between document and summary."""
+        disagreement_answers = []
+        for question in self.answers_doc:
+            answer_doc = self.answers_doc[question]
+            answer_sum = self.answers_sum[question]
+            if answer_doc != answer_sum:
+                disagreement_answers.append((question, answer_doc, answer_sum))
+        return disagreement_answers
 
     def _evaluate_element(self, instance: SummaryDataPoint):
         """Evaluate an instance for hallucination."""
         try:
+            # Parse instance
             document = instance["document"]
             summary = instance["response"]
             if "label" in instance:
                 label = instance["label"]
             else:
                 label = "overall"
+        except Exception as e:
+            print("Exception while parsing instance", e)
+            traceback.print_exc()
+            raise e
 
+        try:
             # Generate questions based on summary
             if self.questions is None or len(self.questions) == 0:
                 self.questions = self.question_generator.generate(summary)
 
-            answers_doc = self.question_answerer.answer(questions=self.questions, context=document)[1]
-            answers_sum = self.question_answerer.answer(questions=self.questions, context=summary)[1]
+            self.answers_doc = self.question_answerer.answer(questions=self.questions, context=document)[1]
+            self.answers_sum = self.question_answerer.answer(questions=self.questions, context=summary)[1]
             metric_results = {}
+        except Exception as e:
+            print("Exception while generating answers", e)
+            traceback.print_exc()
+            raise e
+
+        try:
             # Compute metrics
-            if answers_doc is None or answers_sum is None or self.questions is None:
+            if self.answers_doc is None or self.answers_sum is None or self.questions is None:
                 raise Exception("Validation error - unable to generate answers")
             else:
-                for metric in self.metrics:
+                for metric in self.metric_ids:
                     metric_name = metric.value
                     metric_class = metric.get_class()
                     metric_result, explanation = metric_class.compute(
-                        answers_doc, answers_sum, self.questions, self.n_questions
+                        self.answers_doc, self.answers_sum, self.questions, self.n_questions
                     )
                     metric_results[metric_name] = metric_result
                     metric_results[f"reason_{metric_name}"] = explanation
@@ -160,13 +184,13 @@ class SummaryAccuracy(LlmEvaluator):
                 self.label_counts[label] = self.label_counts.get(label, 0) + 1
             return {
                 "questions": self.questions,
-                "answers_doc": answers_doc,
-                "answers_sum": answers_sum,
+                "answers_doc": self.answers_doc,
+                "answers_sum": self.answers_sum,
                 "label": label,
                 **metric_results,
             }
         except Exception as e:
-            print("Exception in _evaluate_element", e)
+            print("Exception while computing metrics", e)
             traceback.print_exc()
             raise e
 
@@ -197,7 +221,7 @@ class SummaryAccuracy(LlmEvaluator):
     def compute_average_scores(self):
         """Compute average scores for each metric."""
         avg_scores = {}
-        for metric in self.metrics:
+        for metric in self.metric_ids:
             scores = getattr(self, f"{metric}_scores")
             avg_score = self.get_average_scores(scores)
             avg_scores[metric] = avg_score

--- a/athina/helpers/athina_logging_helper.py
+++ b/athina/helpers/athina_logging_helper.py
@@ -64,10 +64,8 @@ class AthinaLoggingHelper:
 
             for eval_result in eval_results:
                 # Construct eval result object
-                failed_percent = 1.0 if eval_result["failure"] else 0.0
-
-                # Wrap metric in a list - in the future, we may support multiple metrics per eval result
-                metrics = [eval_result["metric"]] if "metric" in eval_result else []
+                failed_percent = float(eval_result.get("failure", 0.0))
+                metrics = eval_result.get("metrics", [])
                 athina_eval_result = AthinaEvalResult(
                     job_type=AthinaJobType.LLM_EVAL.value,
                     failed_percent=failed_percent,

--- a/athina/interfaces/result.py
+++ b/athina/interfaces/result.py
@@ -38,20 +38,32 @@ class BatchRunResult:
 
     def to_df(self):
         """
-        Converts the batch run result to a Pandas DataFrame.
+        Converts the batch run result to a Pandas DataFrame, including data and dynamic metrics.
         """
         pd.set_option('display.max_colwidth', 500)
-        df = pd.DataFrame(self.eval_results)
 
-        # Normalize the 'data' column
-        results_df = df.drop(columns=['data', 'name', 'metric']).rename(columns={'failure': 'failed', 'name': 'eval','reason': 'grade_reason'})
-        data_normalized = pd.json_normalize(df['data'])
-        metric_normalized = pd.json_normalize(df['metric']).rename(columns={'id': 'metric_id', 'value': 'metric_value'})
+        df_data = []
+        for item in self.eval_results:
+            # Start with dynamic fields from the 'data' dictionary
+            entry = {key: value for key, value in item['data'].items()}
 
-        # Concatenate the normalized data with the original DataFrame (excluding the 'data' column)
-        df = pd.concat([data_normalized, results_df, metric_normalized], axis=1)
+            # Add fixed fields
+            entry.update({
+                'display_name': item['display_name'],
+                'failed': item['failure'],
+                'grade_reason': item['reason'],
+                'runtime': item['runtime'],
+                'model': item['model']
+            })
+
+            # Add dynamic metrics
+            for metric in item['metrics']:
+                entry[metric['id']] = metric['value']
+
+            df_data.append(entry)
+
+        df = pd.DataFrame(df_data)
         return df
-
 
 class EvalPerformanceReport(TypedDict):
     """

--- a/athina/interfaces/result.py
+++ b/athina/interfaces/result.py
@@ -25,7 +25,7 @@ class LlmEvalResult(TypedDict):
     reason: str
     runtime: int
     model: str
-    metric: Optional[LlmEvalResultMetric]
+    metrics: List[LlmEvalResultMetric]
 
 @dataclass
 class BatchRunResult:

--- a/athina/metrics/metric_type.py
+++ b/athina/metrics/metric_type.py
@@ -2,18 +2,22 @@ from enum import Enum
 from .agreement_score import AgreementScore
 from .hallucination_score import HallucinationScore
 from .contradiction_score import ContradictionScore
+from .passed import Passed
 
 class MetricType(Enum):
     AGREEMENT_SCORE = 'agreement_score'
     HALLUCINATION_SCORE = 'hallucination_score'
     CONTRADICTION_SCORE = 'contradiction_score'
+    PASSED = 'passed'
 
     def get_class(self):
         if self == MetricType.AGREEMENT_SCORE:
             return AgreementScore
-        if self == MetricType.HALLUCINATION_SCORE:
+        elif self == MetricType.HALLUCINATION_SCORE:
             return HallucinationScore
-        if self == MetricType.CONTRADICTION_SCORE:
+        elif self == MetricType.CONTRADICTION_SCORE:
             return ContradictionScore
+        elif self == MetricType.PASSED:
+            return Passed
         else:
             raise NotImplementedError(f"Metric type {self} not implemented.")

--- a/athina/metrics/passed.py
+++ b/athina/metrics/passed.py
@@ -1,0 +1,18 @@
+from typing import Union
+from .metric import Metric
+
+
+class Passed(Metric):
+    """
+    Boolean metric indicating whether the evaluation passed the specified criteria.
+    """
+
+    @staticmethod
+    def compute(passed: Union[int, bool]):
+        """
+        Computes the result.
+
+        Returns:
+            bool: Whether the evaluation passed or not.
+        """
+        return bool(passed)

--- a/examples/run_eval.ipynb
+++ b/examples/run_eval.ipynb
@@ -89,7 +89,7 @@
    "source": [
     "# custom evaluator\n",
     "# Checks if the response mentions black holes\n",
-    "grading_criteria=\"If the response mentions black holes, then fail. Otherwise pass.\"\n",
+    "# grading_criteria=\"If the response mentions black holes, then fail. Otherwise pass.\"\n",
     "CustomGrader(model=eval_model, grading_criteria=grading_criteria).run_batch(data=dataset).to_df()"
    ]
   }

--- a/examples/run_eval.ipynb
+++ b/examples/run_eval.ipynb
@@ -89,7 +89,7 @@
    "source": [
     "# custom evaluator\n",
     "# Checks if the response mentions black holes\n",
-    "# grading_criteria=\"If the response mentions black holes, then fail. Otherwise pass.\"\n",
+    "grading_criteria=\"If the response mentions black holes, then fail. Otherwise pass.\"\n",
     "CustomGrader(model=eval_model, grading_criteria=grading_criteria).run_batch(data=dataset).to_df()"
    ]
   }

--- a/examples/text_summarization.ipynb
+++ b/examples/text_summarization.ipynb
@@ -11,12 +11,16 @@
     "from athina.evals import SummaryAccuracy\n",
     "from athina.keys import AthinaApiKey, OpenAiApiKey\n",
     "from athina.datasets import summarization_sample\n",
+    "from athina.llms.question_answerer_bulk import QuestionAnswererBulk\n",
     "from athina.llms.question_answerer_cot import QuestionAnswererChainOfThought\n",
     "from athina.llms.question_answerer_with_retrieval import QuestionAnswererWithRetrieval\n",
     "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
     "\n",
     "OpenAiApiKey.set_key(os.getenv('OPENAI_API_KEY'))\n",
-    "AthinaApiKey.set_key(os.getenv('ATHINA_API_KE Y'))"
+    "AthinaApiKey.set_key(os.getenv('ATHINA_API_KEY'))"
    ]
   },
   {
@@ -39,8 +43,9 @@
    "outputs": [],
    "source": [
     "# Run summary accuracy evaluation\n",
-    "question_answerer = QuestionAnswererChainOfThought()\n",
-    "SummaryAccuracy(question_answerer=question_answerer, n_questions=5).run_batch(dataset).to_df()"
+    "model = \"gpt-3.5-turbo\"\n",
+    "question_answerer = QuestionAnswererBulk(model=model)\n",
+    "SummaryAccuracy(question_answerer=question_answerer, model=model, n_questions=5).run_batch(dataset).to_df()"
    ]
   }
  ],


### PR DESCRIPTION
- Added support for evaluators to return multiple metrics
- Fixed SummaryAccuracy evaluator
    - Logging to Athina correctly
    - Returns a reason for disagreements now
    - Returns multiple metrics
- RAG Evaluators will now return a boolean `Passed` metric

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated evaluators to return a list of metric identifiers, enhancing the evaluation result representation.

- **New Features**
  - Introduced a `PASSED` metric type for more granular evaluation outcomes.

- **Bug Fixes**
  - Fixed logging helper to properly calculate failed percentages and handle metrics.

- **Documentation**
  - Adjusted example notebooks to align with updated evaluation and summarization logic.

- **Tests**
  - Improved exception handling and added logging within evaluation methods for better debugging.

- **Chores**
  - Streamlined metric handling across various classes and files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->