### PR TITLE
add chat history to context contains enough information evaluator ATH-1029

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "athina"
-version = "1.2.14"
+version = "1.2.15"
 description = "Python SDK to configure and run evaluations for your LLM-based application"
 authors = ["Shiv Sakhuja <shiv@athina.ai>", "Akshat Gupta <akshat@athina.ai>", "Vivek Aditya <vivek@athina.ai>", "Akhil Bisht <akhil@athina.ai>"]
 readme = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the evaluation process to include chat history along with context in determining if the chatbot can answer the user's query.
- **Documentation**
	- Updated user message templates to reflect the inclusion of chat history in evaluations.
- **Chores**
	- Updated the software version from "1.2.14" to "1.2.15" in the project configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->