### PR TITLE
Support double curly brace in custom prompt

### DIFF
--- a/athina/evals/llm/custom_prompt/evaluator.py
+++ b/athina/evals/llm/custom_prompt/evaluator.py
@@ -53,10 +53,10 @@ class CustomPrompt(LlmEvaluator):
             llm_service=llm_service,
             **kwargs,
         )
-         # Create a custom Jinja2 environment with single curly brace delimiters and PreserveUndefined
+         # Create a custom Jinja2 environment with double curly brace delimiters and PreserveUndefined
         self.env = Environment(
-            variable_start_string='{', 
-            variable_end_string='}',
+            variable_start_string='{{',
+            variable_end_string='}}',
             undefined=PreserveUndefined
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "athina"
-version = "1.3.2"
+version = "1.3.3"
 description = "Python SDK to configure and run evaluations for your LLM-based application"
 authors = ["Shiv Sakhuja <shiv@athina.ai>", "Akshat Gupta <akshat@athina.ai>", "Vivek Aditya <vivek@athina.ai>", "Akhil Bisht <akhil@athina.ai>"]
 readme = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced template rendering by updating the Jinja2 environment to use double curly brace delimiters for better compatibility and clarity.

- **Version Update**
  - Upgraded the "athina" Python SDK version from 1.3.2 to 1.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->